### PR TITLE
improve anonymous regex

### DIFF
--- a/wikichanges.js
+++ b/wikichanges.js
@@ -59,7 +59,9 @@ function parse_msg(channel, msg) {
 
   // see if it looks like an anonymous edit
   var user = m[4];
-  var anonymous = user.match(/\d+.\d+.\d+.\d+/) ? true : false;
+  var anonymous = user.match(/^\d+\.\d+\.\d+\.\d+$/) ? true : false;
+  // FIXME: perhaps make exactly ipv4 and add ipv6 support
+  // adding IPv6 might break some things that depend on this being IPv4 (e.g. anon)
 
   // unpack the flags
   var flag = m[2];


### PR DESCRIPTION
Bugfixes mistaking users with username like foo0123456789 for ip address (anonymous users).

IPv6 support should be added and perhaps the IP regex should be fine tuned.
