### PR TITLE
Correct typo that prevents reporting of irc error

### DIFF
--- a/wikichanges.js
+++ b/wikichanges.js
@@ -42,7 +42,7 @@ WikiChanges.prototype = {
     });
 
     this.client.addListener('error', function(msg) {
-      console.log('irc error: ', message);
+      console.log('irc error: ', msg);
     });
   }
 }


### PR DESCRIPTION
I stumbled briefly when the default user name just happened to be in use. After this change I got a clear error message explaining the problem.
