### PR TITLE
package.json: update all dependencies for node 5 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "wikichanges",
   "repository": "https://github.com/edsu/wikichanges",
   "dependencies": {
-    "irc": "0.3.x",
-    "underscore": "1.3.x"
+    "irc": "0.5.x",
+    "underscore": "1.8.x"
   }
 }


### PR DESCRIPTION
* update irc to 0.5.0 (or the latest 0. release)
* update underscore to 1.8.3 (or the latest 1. release)

This fixes wikichanges for me with Node.js v5. I tested with Node.js v5.9.1 and npm v3.7.3 on 64-bit Ubuntu 14.04.

Prior to this change, `npm install` was throwing errors:

```

> iconv@2.1.11 install /heap/tmp/git/edsu/wikichanges/node_modules/iconv
> node-gyp rebuild

make: Entering directory `/heap/tmp/git/edsu/wikichanges/node_modules/iconv/build'
  CC(target) Release/obj.target/libiconv/deps/libiconv/lib/iconv.o
  AR(target) Release/obj.target/iconv.a
  COPY Release/iconv.a
  CXX(target) Release/obj.target/iconv/src/binding.o
  SOLINK_MODULE(target) Release/obj.target/iconv.node
  COPY Release/iconv.node
make: Leaving directory `/heap/tmp/git/edsu/wikichanges/node_modules/iconv/build'

> node-icu-charset-detector@0.1.0 install /heap/tmp/git/edsu/wikichanges/node_modules/node-icu-charset-detector
> node-gyp rebuild

make: Entering directory `/heap/tmp/git/edsu/wikichanges/node_modules/node-icu-charset-detector/build'
  CXX(target) Release/obj.target/node-icu-charset-detector/node-icu-charset-detector.o
In file included from ../node-icu-charset-detector.cpp:2:0:
../node_modules/nan/nan.h:324:27: error: redefinition of ‘template<class T> v8::Local<T> Nan::imp::NanEnsureHandleOrPersistent(const v8::Local<T>&)’
   NAN_INLINE v8::Local<T> NanEnsureHandleOrPersistent(const v8::Local<T> &val) {
                           ^
../node_modules/nan/nan.h:319:17: error: ‘template<class T> v8::Handle<T> Nan::imp::NanEnsureHandleOrPersistent(v8::Handle<T>&)’ previously declared here
   v8::Handle<T> NanEnsureHandleOrPersistent(const v8::Handle<T> &val) {
                 ^
../node_modules/nan/nan.h:344:27: error: redefinition of ‘template<class T> v8::Local<T> Nan::imp::NanEnsureLocal(v8::Handle<T>&)’
   NAN_INLINE v8::Local<T> NanEnsureLocal(const v8::Handle<T> &val) {
                           ^
../node_modules/nan/nan.h:334:27: error: ‘template<class T> v8::Local<T> Nan::imp::NanEnsureLocal(const v8::Local<T>&)’ previously declared here
   NAN_INLINE v8::Local<T> NanEnsureLocal(const v8::Local<T> &val) {
                           ^
../node_modules/nan/nan.h:757:13: error: ‘node::smalloc’ has not been declared
     , node::smalloc::FreeCallback callback
             ^
../node_modules/nan/nan.h:757:35: error: expected ‘,’ or ‘...’ before ‘callback’
     , node::smalloc::FreeCallback callback
                                   ^
../node_modules/nan/nan.h: In function ‘v8::Local<v8::Object> NanNewBufferHandle(char*, size_t, int)’:
../node_modules/nan/nan.h:761:50: error: ‘callback’ was not declared in this scope
         v8::Isolate::GetCurrent(), data, length, callback, hint);
                                                  ^
../node_modules/nan/nan.h:761:60: error: ‘hint’ was not declared in this scope
         v8::Isolate::GetCurrent(), data, length, callback, hint);
                                                            ^
../node_modules/nan/nan.h: In function ‘v8::Local<v8::Object> NanNewBufferHandle(const char*, uint32_t)’:
../node_modules/nan/nan.h:768:67: error: call of overloaded ‘New(v8::Isolate*, const char*&, uint32_t&)’ is ambiguous
     return node::Buffer::New(v8::Isolate::GetCurrent(), data, size);
                                                                   ^
../node_modules/nan/nan.h:768:67: note: candidates are:
In file included from ../node_modules/nan/nan.h:25:0,
                 from ../node-icu-charset-detector.cpp:2:
/home/adamm/.node-gyp/5.9.1/include/node/node_buffer.h:31:40: note: v8::MaybeLocal<v8::Object> node::Buffer::New(v8::Isolate*, v8::Local<v8::String>, node::encoding) <near match>
 NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                        ^
/home/adamm/.node-gyp/5.9.1/include/node/node_buffer.h:31:40: note:   no known conversion for argument 3 from ‘uint32_t {aka unsigned int}’ to ‘node::encoding’
/home/adamm/.node-gyp/5.9.1/include/node/node_buffer.h:43:40: note: v8::MaybeLocal<v8::Object> node::Buffer::New(v8::Isolate*, char*, size_t) <near match>
 NODE_EXTERN v8::MaybeLocal<v8::Object> New(v8::Isolate* isolate,
                                        ^
/home/adamm/.node-gyp/5.9.1/include/node/node_buffer.h:43:40: note:   no known conversion for argument 2 from ‘const char*’ to ‘char*’
In file included from ../node-icu-charset-detector.cpp:2:0:
../node_modules/nan/nan.h: In function ‘v8::Local<v8::Object> NanNewBufferHandle(uint32_t)’:
../node_modules/nan/nan.h:772:61: error: could not convert ‘node::Buffer::New(v8::Isolate::GetCurrent(), ((size_t)size))’ from ‘v8::MaybeLocal<v8::Object>’ to ‘v8::Local<v8::Object>’
     return node::Buffer::New(v8::Isolate::GetCurrent(), size);
                                                             ^
../node_modules/nan/nan.h: In function ‘v8::Local<v8::Object> NanBufferUse(char*, uint32_t)’:
../node_modules/nan/nan.h:779:12: error: ‘Use’ is not a member of ‘node::Buffer’
     return node::Buffer::Use(v8::Isolate::GetCurrent(), data, size);
            ^
make: *** [Release/obj.target/node-icu-charset-detector/node-icu-charset-detector.o] Error 1
make: Leaving directory `/heap/tmp/git/edsu/wikichanges/node_modules/node-icu-charset-detector/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/home/adamm/.nvm/versions/node/v5.9.1/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:276:23)
gyp ERR! stack     at emitTwo (events.js:100:13)
gyp ERR! stack     at ChildProcess.emit (events.js:185:7)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:204:12)
gyp ERR! System Linux 3.13.0-83-generic
gyp ERR! command "/home/adamm/.nvm/versions/node/v5.9.1/bin/node" "/home/adamm/.nvm/versions/node/v5.9.1/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /heap/tmp/git/edsu/wikichanges/node_modules/node-icu-charset-detector
gyp ERR! node -v v5.9.1
gyp ERR! node-gyp -v v3.2.1
gyp ERR! not ok 
npm WARN install:node-icu-charset-detector@0.1.0 node-icu-charset-detector@0.1.0 install: `node-gyp rebuild`
npm WARN install:node-icu-charset-detector@0.1.0 Exit status 1
wikichanges@0.2.7 /heap/tmp/git/edsu/wikichanges
├─┬ irc@0.3.12 
│ ├── ansi-color@0.2.1 
│ ├─┬ iconv@2.1.11 
│ │ └── nan@2.0.9 
│ └─┬ irc-colors@1.2.1 
│   └─┬ hashish@0.0.4 
│     └── traverse@0.6.6 
└── underscore@1.3.3 

npm WARN wikichanges@0.2.7 No license field.
```